### PR TITLE
Configuring Network from Vendor JSON Network Data

### DIFF
--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -122,7 +122,7 @@ class Distro(object):
                                         mirror_info=arch_info)
 
     def apply_network_json(self, settings, bring_up=True):
-        dev_names = self._write_network_from_json(settings)
+        dev_names = self._write_network_json(settings)
         if bring_up:
             return self._bring_up_interfaces(dev_names)
         return False

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -72,7 +72,7 @@ class Distro(object):
         # to write this blob out in a distro format
         raise NotImplementedError()
 
-    @abc.abstractmethod
+    #@abc.abstractmethod
     def _write_network_json(self, settings):
         # In the future use the http://fedorahosted.org/netcf/
         # to write this blob out in a distro format

--- a/cloudinit/distros/__init__.py
+++ b/cloudinit/distros/__init__.py
@@ -72,6 +72,12 @@ class Distro(object):
         # to write this blob out in a distro format
         raise NotImplementedError()
 
+    @abc.abstractmethod
+    def _write_network_json(self, settings):
+        # In the future use the http://fedorahosted.org/netcf/
+        # to write this blob out in a distro format
+        raise NotImplementedError()
+
     def _find_tz_file(self, tz):
         tz_file = os.path.join(self.tz_zone_dir, str(tz))
         if not os.path.isfile(tz_file):
@@ -114,6 +120,12 @@ class Distro(object):
         arch_info = self._get_arch_package_mirror_info(arch)
         return _get_package_mirror_info(availability_zone=availability_zone,
                                         mirror_info=arch_info)
+
+    def apply_network_json(self, settings, bring_up=True):
+        dev_names = self._write_network_from_json(settings)
+        if bring_up:
+            return self._bring_up_interfaces(dev_names)
+        return False
 
     def apply_network(self, settings, bring_up=True):
         # Write it out

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -97,6 +97,7 @@ class Distro(distros.Distro):
             chunk.append("")
             lines.extend(chunk)
 
+        dns = nc.get_dns_servers()
         networks = nc.get_networks()
         for net in networks:
             # only have support for ipv4 so far.
@@ -119,6 +120,7 @@ class Distro(distros.Distro):
             # TODO: hmmm
             if len(gwroute) == 1:
                 chunk.append("  gateway {0}".format(gwroute[0]['gateway']))
+                chunk.append("  dns-nameservers {0}".format(" ".join(dns)))
 
             for route in net['routes']:
                 if route['network'] == '0.0.0.0':
@@ -132,7 +134,7 @@ class Distro(distros.Distro):
         return {'/etc/network/interfaces': "\n".join(lines)}
 
     def _write_network_json(self, settings):
-        files = self._rhel_network_json(settings)
+        files = self._debian_network_json(settings)
         for (fn, data) in files.iteritems():
             util.write_file(fn, data)
         return ['all']

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -108,7 +108,7 @@ class Distro(distros.Distro):
             devname = nc.get_link_devname(link)
             chunk = []
             chunk.append("# network: {0}".format(net['id']))
-            chunk.append("# neutron_network_id: {0}".format(net['neutron_network_id']))
+            chunk.append("# network_id: {0}".format(net['network_id']))
             chunk.append("auto {0}".format(devname))
             chunk.append("iface {0} inet static".format(devname))
             if link['type'] == "vlan":

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -129,6 +129,9 @@ class Distro(distros.Distro):
             if link['type'] == "vlan":
                 chunk.append("  vlan_raw_device {0}".format(devname[:devname.rfind('.')]))
                 chunk.append("  hwaddress ether {0}".format(link['ethernet_mac_address']))
+                if link.has_key('mtu'):
+                    chunk.append('  mtu {0}'.format(link['mtu']))
+
             chunk.append("  address {0}".format(net['ip_address']))
             chunk.append("  netmask {0}".format(net['netmask']))
             gwroute = [route for route in net['routes'] if route['network'] == '0.0.0.0']

--- a/cloudinit/distros/debian.py
+++ b/cloudinit/distros/debian.py
@@ -100,7 +100,12 @@ class Distro(distros.Distro):
             devs.extend(slaves)
             chunk.append("auto {0}".format(bond['id']))
             chunk.append("iface {0} inet manual".format(bond['id']))
-            chunk.append('  bond-mode {0}'.format(bond['bond_mode']))
+            if bond.has_key('bond_mode'):
+                chunk.append('  bond-mode {0}'.format(bond['bond_mode']))
+            if bond.has_key('bond_xmit_hash_policy'):
+                chunk.append('  bond_xmit_hash_policy {0}'.format(bond['bond_xmit_hash_policy']))
+            if bond.has_key('bond_miimon'):
+                chunk.append('  bond-miimon {0}'.format(bond['bond_miimon']))
             chunk.append('  bond-slaves {0}'.format(' '.join(slaves)))
             chunk.append("")
             lines.extend(chunk)

--- a/cloudinit/distros/net_util.py
+++ b/cloudinit/distros/net_util.py
@@ -192,3 +192,6 @@ class NetConfHelper(object):
 
     def get_networks(self):
         return self._settings['networks']
+
+    def get_dns_servers(self):
+        return [x['address'] for x in self._settings['services'] if x['type'] == "dns"]

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -104,6 +104,7 @@ class Distro(distros.Distro):
                 lines.append("SLAVE=yes")
                 files[fn] = "\n".join(lines)
 
+        dns = nc.get_dns_servers()
         networks = nc.get_networks()
         for net in networks:
             # only have support for ipv4 so far.
@@ -138,6 +139,10 @@ class Distro(distros.Distro):
             # TODO: hmmm
             if len(gwroute) == 1:
                 lines.append("GATEWAY={0}".format(gwroute[0]['gateway']))
+                i = 1
+                for server in dns:
+                    lines.append("DNS{0}={1}".format(i, server))
+                    i += 1
 
             files[fn] = "\n".join(lines)
 

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -212,6 +212,8 @@ class Distro(distros.Distro):
         return dev_names
 
     def _dist_uses_systemd(self):
+        # TODO(pquerna): Figure out a more portable way of detecting systemd
+        #                as the active init system. There are other distros out there.
         # Fedora 18 and RHEL 7 were the first adopters in their series
         (dist, vers) = util.system_info()['dist'][:2]
         major = (int)(vers.split('.')[0])

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -216,6 +216,7 @@ class Distro(distros.Distro):
         (dist, vers) = util.system_info()['dist'][:2]
         major = (int)(vers.split('.')[0])
         return ((dist.startswith('Red Hat Enterprise Linux') and major >= 7)
+                or (dist.startswith('CentOS Linux') and major >= 7)
                 or (dist.startswith('Fedora') and major >= 18))
 
     def apply_locale(self, locale, out_fn=None):

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -86,8 +86,17 @@ class Distro(distros.Distro):
             lines.append("USERCTL=no")
             lines.append("NM_CONTROLLED=no")
             lines.append("TYPE=Ethernet")
-            lines.append("BONDING_OPTS=\"mode={0}\"".format(bond['bond_mode']))
+
+            opts = []
+            if bond.has_key('bond_mode'):
+                opts.append('mode={0}'.format(bond['bond_mode']))
+            if bond.has_key('bond_xmit_hash_policy'):
+                opts.append('xmit_hash_policy={0}'.format(bond['bond_xmit_hash_policy']))
+            if bond.has_key('bond_miimon'):
+                opts.append('miimon={0}'.format(bond['bond_miimon']))
+            lines.append("BONDING_OPTS=\"{0}\"".format(" ".join(opts)))
             files[fn] = "\n".join(lines)
+
 
             for slave in bond['bond_links']:
                 slavelink = nc.get_link_by_name(slave)

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -119,7 +119,7 @@ class Distro(distros.Distro):
             lines.append("# Created by cloud-init on instance boot.")
             lines.append("#")
             lines.append("# network: {0}".format(net['id']))
-            lines.append("# neutron_network_id: {0}".format(net['neutron_network_id']))
+            lines.append("# network_id: {0}".format(net['network_id']))
             lines.append("")
             lines.append("DEVICE={0}".format(devname))
             if link['type'] == "vlan":

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -140,6 +140,8 @@ class Distro(distros.Distro):
                 lines.append("VLAN=yes")
                 lines.append("PHYSDEV={0}".format(devname[:devname.rfind('.')]))
                 lines.append("MACADDR={0}".format(link['ethernet_mac_address']))
+                if link.has_key('mtu'):
+                    chunk.append('MTU={0}'.format(link['mtu']))
 
             lines.append("ONBOOT=yes")
             lines.append("BOOTPROTO=static")

--- a/cloudinit/distros/rhel.py
+++ b/cloudinit/distros/rhel.py
@@ -124,7 +124,7 @@ class Distro(distros.Distro):
             if link['type'] == "vlan":
                 lines.append("VLAN=yes")
                 lines.append("PHYSDEV={0}".format(devname[:devname.rfind('.')]))
-                lines.append("HWADDR={0}".format(link['ethernet_mac_address']))
+                lines.append("MACADDR={0}".format(link['ethernet_mac_address']))
 
             lines.append("ONBOOT=yes")
             lines.append("BOOTPROTO=static")

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -189,18 +189,18 @@ def route_pformat():
 
 
 _SECTIONS_RE = re.compile(r"\n(?=\w)")
-_IFCONFIG_RE = re.compile(r"^(?P<name>\w+).*?(?:HWaddr|ether) (?P<mac>[a-f0-9:]+)", re.DOTALL)
+_IFCONFIG_RE = re.compile(r"^(?P<name>\w+).*?(?:HWaddr|ether) (?P<mac>[a-fA-F0-9:]+)", re.DOTALL)
 
 def _parse_ifconfig_output(stdout):
     result = {}
     for section in _SECTIONS_RE.split(stdout):
         match = _IFCONFIG_RE.match(section)
         if match:
-            result[match.group("name")] = match.group("mac")
+            result[match.group("name")] = match.group("mac").lower()
     return result
 
 def find_mac_addresses():
-    output = util.subp(["ifconfig", "-a"])
+    (output, err) = util.subp(["ifconfig", "-a"])
     return _parse_ifconfig_output(output)
 
 def debug_info(prefix='ci-info: '):

--- a/cloudinit/netinfo.py
+++ b/cloudinit/netinfo.py
@@ -200,7 +200,7 @@ def _parse_ifconfig_output(stdout):
     return result
 
 def find_mac_addresses():
-    output = subprocess.check_output(["ifconfig", "-a"])
+    output = util.subp(["ifconfig", "-a"])
     return _parse_ifconfig_output(output)
 
 def debug_info(prefix='ci-info: '):

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -193,7 +193,7 @@ def on_first_boot(data, distro=None):
                         % (type(data)))
 
     networkapplied = False
-    jsonnet_conf = data.get('vendordata', {}).get('network_info')
+    jsonnet_conf = data.get('vendordata_json', {}).get('network_info')
     if jsonnet_conf:
         try:
             LOG.debug("Updating network interfaces from JSON in config drive")

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -193,7 +193,7 @@ def on_first_boot(data, distro=None):
                         % (type(data)))
 
     networkapplied = False
-    jsonnet_conf = data.get('vendordata_raw', {}).get('network')
+    jsonnet_conf = data.get('vendordata_raw', {}).get('network_info')
     if jsonnet_conf:
         try:
             distro_user_config = distro.apply_network_json(jsonnet_conf)

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -160,7 +160,7 @@ def get_ds_mode(cfgdrv_ver, ds_cfg=None, user=None):
     return "net"
 
 
-def read_config_drive(source_dir, version="2012-08-10"):
+def read_config_drive(source_dir, version="2013-10-17"):
     reader = openstack.ConfigDriveReader(source_dir)
     finders = [
         (reader.read_v2, [], {'version': version}),
@@ -193,9 +193,10 @@ def on_first_boot(data, distro=None):
                         % (type(data)))
 
     networkapplied = False
-    jsonnet_conf = data.get('vendordata_raw', {}).get('network_info')
+    jsonnet_conf = data.get('vendordata', {}).get('network_info')
     if jsonnet_conf:
         try:
+            LOG.debug("Updating network interfaces from JSON in config drive")
             distro_user_config = distro.apply_network_json(jsonnet_conf)
             networkapplied = True
         except NotImplementedError:

--- a/cloudinit/sources/DataSourceConfigDrive.py
+++ b/cloudinit/sources/DataSourceConfigDrive.py
@@ -191,10 +191,22 @@ def on_first_boot(data, distro=None):
     if not isinstance(data, dict):
         raise TypeError("Config-drive data expected to be a dict; not %s"
                         % (type(data)))
+
+    networkapplied = False
+    jsonnet_conf = data.get('vendordata_raw', {}).get('network')
+    if jsonnet_conf:
+        try:
+            distro_user_config = distro.apply_network_json(jsonnet_conf)
+            networkapplied = True
+        except NotImplementedError:
+            LOG.debug("Distro does not implement networking setup via Vendor JSON.")
+            pass
+
     net_conf = data.get("network_config", '')
-    if net_conf and distro:
+    if networkapplied is False and net_conf and distro:
         LOG.debug("Updating network interfaces from config drive")
         distro.apply_network(net_conf)
+
     files = data.get('files', {})
     if files:
         LOG.debug("Writing %s injected files", len(files))

--- a/cloudinit/sources/DataSourceOpenStack.py
+++ b/cloudinit/sources/DataSourceOpenStack.py
@@ -17,6 +17,7 @@
 #    along with this program.  If not, see <http://www.gnu.org/licenses/>.
 
 import time
+import json
 
 from cloudinit import log as logging
 from cloudinit import sources
@@ -146,8 +147,12 @@ class DataSourceOpenStack(openstack.SourceMixin, sources.DataSource):
         # if vendordata includes 'cloud-init', then read that explicitly
         # for cloud-init (for namespacing).
         vd = results.get('vendordata')
-        if isinstance(vd, dict) and 'cloud-init' in vd:
-            self.vendordata_raw = vd['cloud-init']
+        if isinstance(vd, dict):
+            if 'cloud-init' in vd:
+                self.vendordata_raw = vd['cloud-init']
+            else:
+                # TODO(pquerna): this is so wrong.
+                self.vendordata_raw = json.dumps(vd)
         else:
             self.vendordata_raw = vd
 

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -211,10 +211,15 @@ class BaseReader(object):
                 False,
                 lambda x: x,
             )
-            files['vendordata'] = (
+            files['vendordata_json'] = (
                 self._path_join("openstack", version, 'vendor_data.json'),
                 False,
                 util.load_json,
+            )
+            files['vendordata'] = (
+                self._path_join("openstack", version, 'vendor_data'),
+                False,
+                lambda x: x,
             )
             return files
 

--- a/cloudinit/sources/helpers/openstack.py
+++ b/cloudinit/sources/helpers/openstack.py
@@ -211,15 +211,10 @@ class BaseReader(object):
                 False,
                 lambda x: x,
             )
-            files['vendordata_json'] = (
+            files['vendordata'] = (
                 self._path_join("openstack", version, 'vendor_data.json'),
                 False,
                 util.load_json,
-            )
-            files['vendordata'] = (
-                self._path_join("openstack", version, 'vendor_data'),
-                False,
-                lambda x: x,
             )
             return files
 

--- a/tests/unittests/test_datasource/test_openstack.py
+++ b/tests/unittests/test_datasource/test_openstack.py
@@ -241,7 +241,7 @@ class TestOpenStackDataSource(test_helpers.HttprettyTestCase):
         self.assertEquals(EC2_META, ds_os.ec2_metadata)
         self.assertEquals(USER_DATA, ds_os.userdata_raw)
         self.assertEquals(2, len(ds_os.files))
-        self.assertEquals(VENDOR_DATA, ds_os.vendordata_raw)
+        self.assertEquals(VENDOR_DATA, json.loads(ds_os.vendordata_raw))
 
     @hp.activate
     def test_bad_datasource_meta(self):


### PR DESCRIPTION
## _Just a Pull Request for review purposes_
- Adds a `apply_network_json` to the distro class.
- Tries to use `apply_network_json` if implemented by the distro and the ConfigDrive contains a `network` section in the vendor data.
- Adds a `NetConfHelper` class to help get link and device names from the network settings.

TOOD:
- ~~DNS~~
- Cleanup
- Tests
- Re-name APIs and get upstream.
